### PR TITLE
Change wording "innovators" to "digital" (toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,13 @@ For a full list of dependancies, or to use with Docker, see the `Dockerfile`
 
 We pull the publishing source code from [the `os-pages` branch](https://github.com/bcgov/digital-toolkit/tree/os-pages). (Do not delete this branch, the build will break).
 
-The public and employees of the BCPS will make changes to the `master` branch. When these changes have been approved, simply merge them to the `os-pages` branch. This will trigger a webhook that will publish the changes live to <https://digital-toolkit.pathfinder.gov.bc.ca/>.
+The public and employees of the BCPS will make changes to the `master` branch. When these changes have been reviewed and approved, simply merge them to the `os-pages` branch with git or GitHub (instructions for GitHub follow). This will trigger a webhook that will publish the changes live to <https://digital-toolkit.pathfinder.gov.bc.ca/>.
+
+In order to merge changes directly on GitHub:
+
+1.  Visit: <https://github.com/bcgov/digital-toolkit/tree/os-pages>
+1.  Click "Pull Request" or visit: <https://github.com/bcgov/digital-toolkit/compare/os-pages...master>
+1.  Create a pull request, giving details outlining the changes. Here is a great place to disscuss changes with other members of the team. You should see "Able to merge. These branches can be automatically merged." at the top of the page. If not, review the changes well. A conflicting change generally means a big change.
+1.  Optionally, assign reviewers and assignees, and lables.
+1.  Click "Create pull request"
+1.  You now have your pull request! You may disscuss it furthur with your team via the comments box, or, you can click the shiny "Merge pull request" button in order to make your changes live on the `os-pages` branch (aka <https://digital-toolkit.pathfinder.gov.bc.ca/>)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BCGov Innovators Toolkit
+# BCGov Digital Toolkit
 
-The BCGov Innovators Toolkit is the reference repository for digital best practices across our teams. Most of our guides are open source, and you are free to use them as you wish.
+The BCGov Digital Toolkit is the reference repository for digital best practices across our teams. Most of our guides are open source, and you are free to use them as you wish.
 
 Our hope is that other digital service teams, both inside and outside of the BC government, will adopt or modify the practices outlined here.
 
@@ -17,12 +17,13 @@ This site was developed using [approved BC Government standards](https://www2.go
   * [Static assets and binary files](#static-assets-and-binary-files)
   * [Modifications made to the default BC Gov theme](#modifications-made-to-the-default-bc-gov-theme)
   * [When you are ready to publish the site](#when-you-are-ready-to-publish-the-site)
+* [Approving changes made on GitHub](#approving-changes-made-on-github)
 
 <!-- /TOC -->
 
 ## Contribute to this Project
 
-[See the wiki](https://github.com/bcgov/innovation-toolkit/wiki) for a full set of instructions on how to contribute to the guides hosted here.
+[See the wiki](https://github.com/bcgov/digital-toolkit/wiki) for a full set of instructions on how to contribute to the guides hosted here.
 
 ## Developer Installation
 
@@ -31,8 +32,8 @@ In order to install this website and the collection of digital guides onto your 
 You may install and run this website locally and you may use its source code as the foundation for a project of your own. However, copying and redistributing the source code without modifications is prohibited.
 
 1.  Ensure you have [Ruby](https://www.ruby-lang.org/en/documentation/installation/), [Bundler](http://bundler.io) and [Jekyll](https://jekyllrb.com/docs/installation/) installed.
-1.  Clone this repository: `git clone https://github.com/bcgov/innovation-toolkit.git`
-1.  Change directory into the project root: `cd innovation-toolkit`
+1.  Clone this repository: `git clone https://github.com/bcgov/digital-toolkit.git`
+1.  Change directory into the project root: `cd digital-toolkit`
 1.  Serve the site locally: `bundle exec jekyll serve --watch`
 
 ### Watching files for changes
@@ -41,7 +42,7 @@ Run `bundle exec jekyll serve --watch` in order to serve the site locally and to
 
 ### Pull requests for website changes
 
-Pull requests to the source code of the website are welcomed and appriciated. In order to contribute to the content of the site [see the wiki](https://github.com/bcgov/innovation-toolkit/wiki).
+Pull requests to the source code of the website are welcomed and appriciated. In order to contribute to the content of the site [see the wiki](https://github.com/bcgov/digital-toolkit/wiki).
 
 ### Static assets and binary files
 
@@ -58,3 +59,11 @@ Some changes made to the [BC Gov Skeleton](https://github.com/bcgov/Gov-2.0-Boot
 **Important!** Set the `JEKYLL_ENV` variable to `production` via the command line by adding it to your build command, like this: `JEKYLL_ENV=production bundle exec jekyll serve` or `JEKYLL_ENV=production jekyll build`
 
 Setting the `JEKYLL_ENV` to `production` will compile the site with certain features enabled, such as analytics.
+
+For a full list of dependancies, or to use with Docker, see the `Dockerfile`
+
+## Approving changes made on GitHub
+
+We pull the publishing source code from [the `os-pages` branch](https://github.com/bcgov/digital-toolkit/tree/os-pages). (Do not delete this branch, the build will break).
+
+The public and employees of the BCPS will make changes to the `master` branch. When these changes have been approved, simply merge them to the `os-pages` branch. This will trigger a webhook that will publish the changes live to <https://digital-toolkit.pathfinder.gov.bc.ca/>.

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: "Digital Toolkit"
 nav-trigger-text: "Select Navigation"
 contribute-link-text: "Contribute on GitHub"
 steps-name-text: "Good Practices"
-contribute-link: "https://github.com/bcgov/innovation-toolkit/wiki/Contributing-to-the-Digital-Toolkit"
+contribute-link: "https://github.com/bcgov/digital-toolkit/wiki/Contributing-to-the-Digital-Toolkit"
 
 # Site description
 description: "This toolkit offers a set of steps that can be followed when developing a digital service inside (or outside) the British Columbia Public Service."
@@ -14,7 +14,7 @@ feedback-email: "jim.rabb@gov.bc.ca"
 
 # Site paths - set these in production!
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://innovation-toolkit.pathfinder.bcgov" # the base hostname & protocol for your site
+url: "https://digital-toolkit.pathfinder.gov.bc.ca/" # the base hostname & protocol for your site
 
 # Excerpt the first sentence and use that for the .excerpt
 # Alternatively, we could pipe the excerpt to | truncatewords:75


### PR DESCRIPTION
@jackieredmond @RobertGoesByJim These changes change the wording (mostly in the README) from "innovators" to "digital". Most of these changes will not go onto the live site but are used more inside site documentation. 